### PR TITLE
Allow arbitrary extra options in runMOFA (and fix a bug)

### DIFF
--- a/MOFAtools/R/runMOFA.R
+++ b/MOFAtools/R/runMOFA.R
@@ -108,7 +108,10 @@ runMOFA <- function(object, DirOptions, ..., mofaPath="mofa") {
     message("Running MOFA command: ", paste(collapse=" ", shQuote(c(mofaPath, argv))))
   }
   # Run!
-  system2(command=mofaPath, args=shQuote(argv), wait=T)
+  exitcode <- system2(command=mofaPath, args=shQuote(argv), wait=T)
+  if (exitcode != 0) {
+    stop(paste("mofa command failed with exit code", exitcode))
+  }
   
   # Load trained model
   object <- loadModel(DirOptions$outFile, object)

--- a/MOFAtools/R/runMOFA.R
+++ b/MOFAtools/R/runMOFA.R
@@ -9,6 +9,7 @@
 #' @param object an untrained \code{\link{MOFAmodel}}
 #' @param DirOptions list with I/O options, should contain at least 'dataDir' where the input matrices as stored as .txt files and 'outFile' where the model is going to be stored as a .hdf5 file
 #' @param ... Extra options to add to the mofa command
+#' @param mofaPath Path the the mofa script. Use this if mofa is not in your $PATH.
 #' @return a trained \code{\link{MOFAmodel}}
 #' @export
 runMOFA <- function(object, DirOptions, ..., mofaPath="mofa") {

--- a/MOFAtools/R/runMOFA.R
+++ b/MOFAtools/R/runMOFA.R
@@ -8,51 +8,107 @@
 #' @description train a \code{\link{MOFAmodel}}
 #' @param object an untrained \code{\link{MOFAmodel}}
 #' @param DirOptions list with I/O options, should contain at least 'dataDir' where the input matrices as stored as .txt files and 'outFile' where the model is going to be stored as a .hdf5 file
+#' @param ... Extra options to add to the mofa command
 #' @return a trained \code{\link{MOFAmodel}}
 #' @export
-runMOFA <- function(object, DirOptions) {
+runMOFA <- function(object, DirOptions, ..., mofaPath="mofa") {
   
   # Sanity checks
-  if (class(object) != "MOFAmodel") stop("'object' has to be an instance of MOFAmodel")
+  if (! is(object, "MOFAmodel")) stop("'object' has to be an instance of MOFAmodel")
   stopifnot(all(c("dataDir","outFile") %in% names(DirOptions)))
-  
-  # Prepare command
-  command <- paste(sep=" ",
-  # "mofa",
-  "--inFiles", paste(paste0(DirOptions$dataDir, "/", viewNames(object), ".txt"), collapse = " "),
-  "--header_cols --header_rows",
-  "--delimiter", paste0('\'',object@DataOpts$delimiter,'\''),
-  "--outFile", DirOptions$outFile,
-  "--views", paste(viewNames(object), collapse=" "),
-  "--likelihoods", paste(object@ModelOpts$likelihood, collapse=" "),
-  "--factors", object@ModelOpts$numFactors,
-  "--iter", object@TrainOpts$maxiter,
-  "--dropR2", object@TrainOpts$DropFactorThreshold,
-  "--tolerance", object@TrainOpts$tolerance
+
+  arglist <- list(
+    inFiles = paste0(DirOptions$dataDir, "/", viewNames(object), ".txt"),
+    header_cols = TRUE,
+    header_rows = TRUE,
+    delimiter = object@DataOpts$delimiter,
+    outFile = DirOptions$outFile,
+    views = viewNames(object),
+    likelihoods = object@ModelOpts$likelihood,
+    factors = object@ModelOpts$numFactors,
+    iter = object@TrainOpts$maxiter,
+    dropR2 =  object@TrainOpts$DropFactorThreshold,
+    tolerance = object@TrainOpts$tolerance
   )
+
+  # Setting the below arguments to NULL doesn't actually add them to
+  # the argument list, but reserves that argument name to prevent
+  # extra.arglist from using it.
   if (!is.null(object@ModelOpts$covariates)) {
-    command <- paste(command, sep=" ",
-                     "--covariatesFile", file.path(DirOptions$dataDir, "covariates.txt"),
-                     "--scale_covariates", rep(1,ncol(object@ModelOpts$covariates)))
+    arglist$covariatesFile <- file.path(DirOptions$dataDir, "covariates.txt")
+    arglist$scale_covariates <- rep(1,ncol(object@ModelOpts$covariates))
+  } else {
+    arglist$covariatesFile <- NULL
+    arglist$scale_covariates <- NULL
   }
-  if (object@ModelOpts$learnIntercept == T) { command <- paste(command, "--learnIntercept", sep=" ") }
-  if (object@ModelOpts$sparsity == F) { command <- paste(command, "--learnTheta 0", sep=" ") }
-  
-  if (object@DataOpts$centerFeatures == T) { command <- paste(command, "--center_features", sep=" ") }
-  if (object@DataOpts$scaleViews == T) { command <- paste(command, "--scale_views", sep=" ") }
+  arglist$learnIntercept <- as.logical(object@ModelOpts$learnIntercept)
+  if (! object@ModelOpts$sparsity) {
+    arglist$learnTheta <- 0
+  } else {
+    arglist$learnTheta <- NULL
+  }
+
+  arglist$center_features <- as.logical(object@DataOpts$centerFeatures)
+  arglist$scale_views <- as.logical(object@DataOpts$scaleViews)
   if (object@DataOpts$removeIncompleteSamples == T) { command <- paste(command, "--RemoveIncompleteSamples", sep=" ") }
-  
-  if (object@TrainOpts$verbose == T) { command <- paste(command, "--verbose", sep=" ") }
-  
+  arglist$verbose <- as.logical(object@TrainOpts$verbose)
+
+  extra.arglist <- list(...)
+  if (any(is.na(names(extra.arglist)) | names(extra.arglist) == "")) {
+    stop("All extra options must be named")
+  }
+
+  # Remove leading "--" from extra arg names if present (it will be
+  # added back later)
+  names(arglist) <- sub("^--", "", names(arglist))
+  conflicting.argnames <- intersect(names(extra.arglist), names(arglist))
+  if (length(conflicting.argnames) > 0)
+    stop(paste0("You cannot pass the following arguments as extra options to runMOFA: ",
+      deparse(conflicting.argnames)))
+
+  # No conflicting argument names,
+  arglist <- c(arglist, extra.arglist)
+
+  argv <- character(0)
+  for (argname in names(arglist)) {
+    argval <- arglist[[argname]]
+    argname <- paste0("--", argname)
+
+    if (is.null(argval)) {
+      # Placeholder option; don't add it
+    }
+    if (is.logical(argval)) {
+      # Flag option
+      if (length(argval) != 1) {
+        stop(paste("Invalid argument value:", deprase(argval)))
+      } else if (argval == FALSE || is.na(argval)) {
+        # Unset flag: don't add it
+      } else if (argval == TRUE) {
+        # Set flag: add it
+        argv <- c(argv, argname)
+      }
+    } else {
+      # Option with arguments: add the option followed by it args
+      argv <- c(argv, argname, argval)
+    }
+  }
+  argv <- unlist(argv)
+
+  if (length(mofaPath) != 1) stop("Invalid mofaPath")
+
   # If output already exists, remove it
   if (file.exists(DirOptions$outFile)) {
+    if (arglist$verbose) {
+      message("Deleting old output file")
+      }
     file.remove(DirOptions$outFile)
   }
-  
+
+  if (arglist$verbose) {
+    message("Running MOFA command: ", paste(collapse=" ", shQuote(c(mofaPath, argv))))
+  }
   # Run!
-  # system(command, ignore.stdout = F, ignore.stderr = T, wait=F)
-  # system2(command="mofa", args=command, wait=F)
-  system2(command="mofa", args=command, wait=T)
+  system2(command=mofaPath, args=shQuote(argv), wait=T)
   
   # Load trained model
   object <- loadModel(DirOptions$outFile, object)


### PR DESCRIPTION
For example, you could pass seed=12345 as an additional argument to
runMOFA, and it would add "--seed 12345" to the command line. This
does not allow manually overriding any of the command-line arguments
that runMOFA sets based on the values in the mofa object itself (e.g.
you cannot add inFiles as an extra option).

Also adds a verbose option that echoes the command to be run as well
as adding "--verbose" to the command itself.

Lastly, this commit fixes a probable bug that could unintentionally
duplicate all the arguments before to "--scale_covariates" if there
are multiple covariates in the model.